### PR TITLE
pip-requires fix

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -2,4 +2,4 @@ flask
 sqlalchemy
 sqlalchemy-migrate
 pychef
-daemon
+python-daemon


### PR DESCRIPTION
daemon is a different package to python-daemon and doesn't provide
DaemonContext
