### PR TITLE
Updates to and tests for util_childof

### DIFF
--- a/opencenter/webapp/ast.py
+++ b/opencenter/webapp/ast.py
@@ -202,19 +202,26 @@ def util_childof(context, parent_name_or_id):
         # this is a name
         parent = api._model_query('nodes',
                                   'name="%s"' % parent_name_or_id)
-        if parent is None:
+        try:
+            parent_id = parent[0]['id']
+        except IndexError:
             return False
 
-        parent_id = parent[0]['id']
-
     current_parent = node['facts'].get('parent_id', None)
-    while(current_parent):
+    #checked_nodes prevents infinite loop
+    checked_nodes = set()
+    while current_parent:
         if current_parent == parent_id:
             return True
 
         # otherwise, get parent of this parent
         parent = api._model_get_by_id('nodes', current_parent)
         current_parent = parent['facts'].get('parent_id', None)
+        if current_parent in checked_nodes:
+            #if there's a loop True may be just as accurate as False
+            break
+        else:
+            checked_nodes.add(current_parent)
 
     return False
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -251,6 +251,24 @@ class AstTests(OpenCenterTestCase):
         self.assertEquals(len(result), 1)
         self.assertTrue(result[0]['name'] == 'node1')
 
+    def test_childof(self):
+        query = 'childof("container")'
+        result = self._model_filter('nodes', query)
+        self.assertEqual(len(result), 2)
+        query = 'childof("badname")'
+        result = self._model_filter('nodes', query)
+        self.assertEqual(len(result), 0)
+        self.node3 = self._model_create('nodes', name='node3')
+        self.node4 = self._model_create('nodes', name='node4')
+        self._model_create('facts', node_id=self.node3['id'],
+                           key='parent_id', value=self.node4['id'])
+        self._model_create('facts', node_id=self.node4['id'],
+                           key='parent_id', value=self.node3['id'])
+        query = 'childof("node2")'
+        result = self._model_filter('nodes', query)
+        #this tests for (gets stuck)  infinite loop
+        self.assertEqual(len(result), 0)
+
     # fix this by db abstraction...
     # def test_017_relations(self):
     #     # this should actually work....


### PR DESCRIPTION
Fixes error where util_childof was throwing an IndexError exception if the parent node name given did not exist.

Introduced fix to prevent infinite loops where a node is a descendent of itself.

Added tests for util_childof
