### PR TITLE
move the vip facts to the nova backend

### DIFF
--- a/opencenter/backends/nova-controller/facts.json
+++ b/opencenter/backends/nova-controller/facts.json
@@ -2,17 +2,5 @@
     {"ha_infra": {"type": "string",
                   "settable": false,
                   "converge": true,
-                  "cluster_wide": true}},
-    {"nova_api_vip": {"type": "string",
-                      "settable": true,
-                      "converge": true,
-                      "cluster_wide": true}},
-    {"nova_rabbitmq_vip": {"type": "string",
-                           "settable": true,
-                           "converge": true,
-                           "cluster_wide": true}},
-    {"nova_mysql_vip": {"type": "string",
-                        "settable": true,
-                        "converge": true,
-                        "cluster_wide": true}}
+                  "cluster_wide": true}}
 ]

--- a/opencenter/backends/nova/facts.json
+++ b/opencenter/backends/nova/facts.json
@@ -41,5 +41,17 @@
     {"nova_role": {"type": "string",
                    "settable": false,
                    "inheritance": "child_clobber",
-                   "converge": true}}
+                   "converge": true}},
+    {"nova_api_vip": {"type": "string",
+                      "settable": true,
+                      "converge": true,
+                      "cluster_wide": true}},
+    {"nova_rabbitmq_vip": {"type": "string",
+                           "settable": true,
+                           "converge": true,
+                           "cluster_wide": true}},
+    {"nova_mysql_vip": {"type": "string",
+                        "settable": true,
+                        "converge": true,
+                        "cluster_wide": true}}
 ]


### PR DESCRIPTION
keep the nova-controller backend from being pulled into compute nodes.
