### PR TITLE
Set nova:libvirt:vncserver_listen to 0.0.0.0 as default.

### DIFF
--- a/opencenter/backends/chef-client/environment.tmpl
+++ b/opencenter/backends/chef-client/environment.tmpl
@@ -52,6 +52,9 @@
         "root_network_acl": "%"
     },
     "nova": {
+        "libvirt": {
+            "vncserver_listen": "0.0.0.0"
+        },
         "network": {
             "fixed_range": "${facts['nova_vm_fixed_range']}",
             "dmz_cidr": "${facts['nova_dmz_cidr']}",


### PR DESCRIPTION
Fixes #417 
