### PR TITLE
Reverting 0000596176 since it's adding double-quotes around all values

### DIFF
--- a/opencenter/backends/chef-client/__init__.py
+++ b/opencenter/backends/chef-client/__init__.py
@@ -65,14 +65,12 @@ class ChefClientBackend(opencenter.backends.Backend):
                         if fact in cluster_attributes:
                             raise KeyError('fact already exists')
 
-                        cluster_attributes[fact] = json.dumps(
-                            node['facts'][fact])
+                        cluster_attributes[fact] = node['facts'][fact]
                     else:
                         if fact in node_attributes:
                             raise KeyError('fact already exists')
 
-                        node_attributes[fact] = json.dumps(
-                            node['facts'][fact])
+                        node_attributes[fact] = node['facts'][fact]
 
         # now generate the json from the facts
         environment_template = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
```
>>> test["ohai"]
'haaai!'
>>> json.dumps(test["ohai"])
'"haaai!"'
>>>
```
