### PR TITLE
Serialize facts when necessary

### DIFF
--- a/opencenter/backends/chef-client/__init__.py
+++ b/opencenter/backends/chef-client/__init__.py
@@ -62,8 +62,8 @@ class ChefClientBackend(opencenter.backends.Backend):
                     self.logger.debug('Invalid fact: %s' % fact)
                 else:
                     # serialize non-string facts so we can safely embed in
-                    # template which gets de-serialized later
-                    if isinstance(node['facts'][fact], unicode):
+                    # template (which gets de-serialized later)
+                    if isinstance(node['facts'][fact], basestring):
                         fact_serialized = node['facts'][fact]
                     else:
                         fact_serialized = json.dumps(node['facts'][fact])

--- a/opencenter/backends/chef-client/__init__.py
+++ b/opencenter/backends/chef-client/__init__.py
@@ -67,7 +67,7 @@ class ChefClientBackend(opencenter.backends.Backend):
                         fact_serialized = node['facts'][fact]
                     else:
                         fact_serialized = json.dumps(node['facts'][fact])
-            
+
                     if fact_info['cluster_wide'] is True:
                         if fact in cluster_attributes:
                             raise KeyError('fact already exists')

--- a/opencenter/backends/chef-client/__init__.py
+++ b/opencenter/backends/chef-client/__init__.py
@@ -61,16 +61,23 @@ class ChefClientBackend(opencenter.backends.Backend):
                 if fact_info is None or 'cluster_wide' not in fact_info:
                     self.logger.debug('Invalid fact: %s' % fact)
                 else:
+                    # serialize non-string facts so we can safely embed in
+                    # template which gets de-serialized later
+                    if isinstance(node['facts'][fact], unicode):
+                        fact_serialized = node['facts'][fact]
+                    else:
+                        fact_serialized = json.dumps(node['facts'][fact])
+            
                     if fact_info['cluster_wide'] is True:
                         if fact in cluster_attributes:
                             raise KeyError('fact already exists')
 
-                        cluster_attributes[fact] = node['facts'][fact]
+                        cluster_attributes[fact] = fact_serialized
                     else:
                         if fact in node_attributes:
                             raise KeyError('fact already exists')
 
-                        node_attributes[fact] = node['facts'][fact]
+                        node_attributes[fact] = fact_serialized
 
         # now generate the json from the facts
         environment_template = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
The environment/node templates assume we're passing in serialized facts (since we deserialize on the way out), so this change serializes the non-basestrings .
